### PR TITLE
Fix: Standardize README title to uppercase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# welcome2
+# WELCOME2
 This repository holds a collection of code samples, examples, best practices and other documentation. Samples here will be kept up to date as we release product updates that affect them.
 
 Please report any issues found or difficulty experienced with any sample or document so we can improve the quality over time


### PR DESCRIPTION
## Summary
Changes the README title from "welcome2" to "WELCOME2" to follow the team's decision to standardize on all caps for README titles.

## Related Issue
Resolves #1 

## Changes Made
- Updated README.md title from `# welcome2` to `# WELCOME2`

## Testing
- [x] README displays correctly with uppercase title
- [x] No other formatting affected