### PR TITLE
Fix: Update Best Practices README title to uppercase

### DIFF
--- a/docs/best practices/readme.md
+++ b/docs/best practices/readme.md
@@ -1,3 +1,3 @@
-# Best Practice2
+# BEST PRACTICE2
 
 These are approaches that we have gathered over time. They are not "must do" but we've found they help ensure project success


### PR DESCRIPTION
## Summary
Updates the Best Practices README title from "Best Practice2" to "BEST PRACTICE2" to conform to the new team standard.

## Related Issue
Resolves #7 - "The Best Practices readme does not conform to new standard"

## Changes Made
- Changed title in `docs/best practices/readme.md` from `# Best Practice2` to `# BEST PRACTICE2`
- Follows the team decision that all README titles should be in all caps

## Testing
- [x] README displays correctly with uppercase title
- [x] No other formatting affected