### PR TITLE
Fix DataElement sample: Add DataElement to collection before updating

### DIFF
--- a/samples/Write dataelement.cs
+++ b/samples/Write dataelement.cs
@@ -5,6 +5,9 @@ VIZNET.Shared.DataElements.Collections.DataElementCollection __dec = VIZNET.Shar
 DataElement __de = DataElementEngine.NewDataElement("a2.de");
 __de.Value = 1223;
 
+//Add the DataElement to the collection before updating
+__dec.Add(__de);
+
 MethodReturnInfo __mri = MyConnection.UpdateDataElements(__dec);
 
 //Check that the write was successful:


### PR DESCRIPTION
Fixes #14

## Problem
The Write DataElement sample was creating a DataElement and setting its value, but never adding it to the DataElementCollection before calling `UpdateDataElements()`. This meant the update operation was trying to work with an empty collection.

## Solution
Added the missing line `__dec.Add(__de);` to add the DataElement to the collection before the update operation.

## Changes
- Added `__dec.Add(__de);` after setting the DataElement value and before calling `UpdateDataElements()`
- Added explanatory comment for clarity

This ensures the DataElement is properly included in the collection when the update is performed.